### PR TITLE
add ref to aditir.rb

### DIFF
--- a/data/aditir.rb
+++ b/data/aditir.rb
@@ -528,3 +528,11 @@ entry!('arora2018optimization',
   author('Sanjeev Arora and Nadav Cohen and Elad Hazan'),
   pages(244, 253),
 nil)
+
+entry!('diamond2016cvxpy',
+  jmlr(2016, 17),
+  title('CVXPY: A Python-Embedded Modeling Language for Convex Optimization'),
+  author('S. Diamond and S. Boyd'), 
+  pages(1, 5), 
+nil)
+


### PR DESCRIPTION
Adding reference no. [2] [CVXPY: A Python-Embedded Modeling Language for Convex Optimization](https://stanford.edu/~boyd/papers/cvxpy_paper.html) in the paper [Adversarial Training Can Hurt Generalization](https://openreview.net/pdf?id=SyxM3J256E)