### PR TITLE
Add/Fix ACL '21 Cites

### DIFF
--- a/all.bib
+++ b/all.bib
@@ -1758,7 +1758,7 @@
   year = {2018},
 }
 @inproceedings{lin2014microsoft,
-  author = {Tsung-Yi Lin and Michael Maire and Serge Belongie and James Hays and Pietro Perona and  Deva Ramanan and Piotr Doll{'a}r and C Lawrence Zitnick},
+  author = {Tsung-Yi Lin and Michael Maire and Serge Belongie and James Hays and Pietro Perona and  Deva Ramanan and Piotr Doll{\'a}r and C. Lawrence Zitnick},
   booktitle = {European Conference on Computer Vision (ECCV)},
   pages = {740--755},
   title = {Microsoft {COCO}: Common objects in context},
@@ -3301,7 +3301,7 @@
   author = {Tolga Bolukbasi and Kai-Wei Chang and James Y Zou and Venkatesh Saligrama and Adam T Kalai},
   booktitle = {Advances in Neural Information Processing Systems (NeurIPS)},
   pages = {4349--4357},
-  title = {Man is to computer programmer as woman is to homemaker? debiasing word embeddings},
+  title = {Man is to computer programmer as woman is to homemaker? {Debiasing} word embeddings},
   year = {2016},
 }
 @inproceedings{maurer2009empirical,
@@ -5361,7 +5361,7 @@
 @inproceedings{kwiatkowski2019natural,
   author = {Tom Kwiatkowski and Jennimaria Palomaki and Olivia Redfield and Michael Collins and Ankur Parikh and Chris Alberti and Danielle Epstein and Illia Polosukhin and Matthew Kelcey and Jacob Devlin and Kenton Lee and Kristina N. Toutanova and Llion Jones and Ming-Wei Chang and Andrew Dai and Jakob Uszkoreit and Quoc Le and Slav Petrov},
   booktitle = {Association for Computational Linguistics (ACL)},
-  title = {Natural Questions: a Benchmark for Question Answering Research},
+  title = {Natural Questions: A Benchmark for Question Answering Research},
   year = {2019},
 }
 @inproceedings{cafarella2009data,
@@ -10870,7 +10870,7 @@
   year = {2020},
 }
 @inproceedings{karamcheti2020decomposition,
-  author = {Sidd Karamcheti and Dorsa Sadigh and Percy Liang},
+  author = {Siddharth Karamcheti and Dorsa Sadigh and Percy Liang},
   booktitle = {EMNLP Workshop for Interactive and Executable Semantic Parsing (IntEx-SemPar)},
   title = {Learning Adaptive Language Interfaces through Decomposition},
   year = {2020},
@@ -25550,7 +25550,7 @@
   author = {A. Schein and Lyle H. Ungar},
   journal = {Machine Learning},
   pages = {235--265},
-  title = {Active learning for logistic regression: an evaluation},
+  title = {Active learning for logistic regression: An evaluation},
   volume = {68},
   year = {2007},
 }
@@ -25578,11 +25578,11 @@
   author = {Jeffrey P Bigham and Chandrika Jayant and Hanjie Ji and Greg Little and Andrew Miller and Robert C Miller and Robin Miller and Aubrey Tatarowicz and Brandyn White and Samual White and Tom Yeh},
   booktitle = {User Interface Software and Technology (UIST)},
   pages = {333--342},
-  title = {Vizwiz: nearly real-time answers to visual questions},
+  title = {{VizWiz}: nearly real-time answers to visual questions},
   year = {2010},
 }
 @article{houlsby2011bayesian,
-  author = {Neil Houlsby and Ferenc Husz{'a}r and Zoubin Ghahramani and M{'a}t{'e} Lengyel},
+  author = {Neil Houlsby and Ferenc Husz{\'a}r and Zoubin Ghahramani and M{\'a}t{\'e} Lengyel},
   journal = {arXiv preprint arXiv:1112.5745},
   title = {{B}ayesian active learning for classification and preference learning},
   year = {2011},
@@ -25662,9 +25662,9 @@
   title = {Active Learning for Visual Question Answering: An Empirical Study},
   year = {2017},
 }
-@article{shen2017deep,
+@inproceedings{shen2017deep,
   author = {Yanyao Shen and Hyokun Yun and Zachary C Lipton and Yakov Kronrod and Animashree Anandkumar},
-  journal = {arXiv preprint arXiv:1707.05928},
+  booktitle = {Proceedings of the Second Workshop on Representation Learning for NLP (Repl4NLP)},
   title = {Deep active learning for named entity recognition},
   year = {2017},
 }
@@ -25758,7 +25758,7 @@
 @inproceedings{tan2019lxmert,
   author = {Hao Hao Tan and Mohit Bansal},
   booktitle = {Empirical Methods in Natural Language Processing (EMNLP)},
-  title = {LXMERT: Learning Cross-Modality Encoder Representations from Transformers},
+  title = {{LXMERT}: Learning Cross-Modality Encoder Representations from Transformers},
   year = {2019},
 }
 @inproceedings{paszke2019pytorch,

--- a/data/chaganty.rb
+++ b/data/chaganty.rb
@@ -186,7 +186,7 @@ entry!('lin2004rouge',
        inproceedings('NTCIR Workshop', 2004),
 )
 
-entry!('cohan2016revisiting', 
+entry!('cohan2016revisiting',
        title('Revisiting Summarization Evaluation for Scientific Articles'),
        author('Arman Cohan and Nazli Goharian'),
        lrec(2016),
@@ -198,7 +198,7 @@ entry!('lavie2009meteor',
        article('Machine Translation', 2009, 23),
      )
 
-entry!('denkowski2014meteor', 
+entry!('denkowski2014meteor',
        title('Meteor Universal: Language Specific Translation Evaluation for Any Target Language'),
        author('Michael Denkowski and Alon Lavie'),
        inproceedings('Workshop on Statistical Machine Translation', 2014),
@@ -238,35 +238,35 @@ entry!('paulus2018deep',
   )
 
 entry!('lin2014microsoft',
-  author('Tsung-Yi Lin and Michael Maire and Serge Belongie and James Hays and Pietro Perona and  Deva Ramanan and Piotr Doll{\'a}r and C Lawrence Zitnick'), 
+  author('Tsung-Yi Lin and Michael Maire and Serge Belongie and James Hays and Pietro Perona and  Deva Ramanan and Piotr Doll{\\\'a}r and C. Lawrence Zitnick'),
   eccv(2014),
   pages(740,755),
   title('Microsoft {COCO}: Common objects in context'),
   )
 
 entry!('conroy2008mind',
-  author('John M Conroy and Hoa Trang Dang'), 
+  author('John M Conroy and Hoa Trang Dang'),
   coling(2008),
   pages(145,152),
   title('Mind the Gap : Dangers of Divorcing Evaluations of Summary Content from Linguistic Quality'),
   )
 
 entry!('snover2006ter',
-  author('Matthew Snover and Bonnie Dorr and Richard Schwartz and Linnea Micciulla and John Makhoul'), 
+  author('Matthew Snover and Bonnie Dorr and Richard Schwartz and Linnea Micciulla and John Makhoul'),
   inproceedings('Association for Machine Translation in the Americas', 2006),
   pages(223,231),
   title('A Study of Translation Edit Rate with Targeted Human Annotation'),
   )
 
 entry!('chang2017affordable',
-  author('Cheng Chang and Runzhe Yang and Lu Chen and Xiang Zhou and Kai Yu'), 
+  author('Cheng Chang and Runzhe Yang and Lu Chen and Xiang Zhou and Kai Yu'),
   emnlp(2017),
   pages(223,231),
   title('Affordable On-Line Dialogue Policy Learning'),
   )
 
 entry!('dang2006overview',
-  author('Hoa Trang Dang'), 
+  author('Hoa Trang Dang'),
   inproceedings('Document Understanding Conference', 2006),
   title('Overview of {DUC} 2006'),
   )
@@ -407,7 +407,7 @@ entry!('recht2018cifar',
    phdthesis('Brown University', 2010),
    title('Any domain parsing: automatic domain adaptation for natural language parsing'),
    )
- 
+
 entry!('foster2011news',
   author('Jennifer Foster and Ozlem Cetinoglu and Joachim Wagner and Joseph Le Roux and Joakim Nivre and Deirdre Hogan and Josef VanGenabith'),
   aclijcnlp(2011),
@@ -488,7 +488,7 @@ entry!('salton1965smart',
   author('Gerard Salton and Michael E. Lesk'),
   title('The {SMART} automatic document retrieval systems—an illustration'),
   pages(391, 398),
-  article('Communications of the ACM', 1965, 8), number(6), 
+  article('Communications of the ACM', 1965, 8), number(6),
   )
 
 entry!('cleverdon1962report',
@@ -512,7 +512,7 @@ entry!('harman1992overview',
 entry!('voorhees2007trec',
   author('Ellen M. Voorhees '),
   pages(51, 54),
-  article('Communications of the ACM', 2007, 50), number(11), 
+  article('Communications of the ACM', 2007, 50), number(11),
   title("TREC: Continuing Information Retrieval's Tradition of Experimentation"),
   )
 

--- a/data/fereshte.rb
+++ b/data/fereshte.rb
@@ -319,7 +319,7 @@ entry!('louizos2015variational',
 
 entry!('bolukbasi2016man',
   neurips(2016),
-  title('Man is to computer programmer as woman is to homemaker? debiasing word embeddings'),
+  title('Man is to computer programmer as woman is to homemaker? {Debiasing} word embeddings'),
   author('Tolga Bolukbasi and Kai-Wei Chang and James Y Zou and Venkatesh Saligrama and Adam T Kalai'),
   pages(4349, 4357),
 )

--- a/data/ice.rb
+++ b/data/ice.rb
@@ -725,7 +725,7 @@ entry!('soricut2006automatic',
 
 entry!('kwiatkowski2019natural',
   acl(2019),
-  title('Natural Questions: a Benchmark for Question Answering Research'),
+  title('Natural Questions: A Benchmark for Question Answering Research'),
   author('Tom Kwiatkowski and Jennimaria Palomaki and Olivia Redfield and Michael Collins and Ankur Parikh and Chris Alberti and Danielle Epstein and Illia Polosukhin and Matthew Kelcey and Jacob Devlin and Kenton Lee and Kristina N. Toutanova and Llion Jones and Ming-Wei Chang and Andrew Dai and Jakob Uszkoreit and Quoc Le and Slav Petrov'),
 )
 

--- a/data/pliang-mine.rb
+++ b/data/pliang-mine.rb
@@ -73,7 +73,7 @@ entry!('xie2020outputs',
 
 entry!('karamcheti2020decomposition',
   title('Learning Adaptive Language Interfaces through Decomposition'),
-  author('Sidd Karamcheti and Dorsa Sadigh and Percy Liang'),
+  author('Siddharth Karamcheti and Dorsa Sadigh and Percy Liang'),
   inproceedings('EMNLP Workshop for Interactive and Executable Semantic Parsing (IntEx-SemPar)', 2020),
   url('https://arxiv.org/pdf/2010.05190.pdf'),
 )

--- a/data/siddk.rb
+++ b/data/siddk.rb
@@ -588,7 +588,7 @@ entry!('mccoy2020berts',
 )
 
 #######################################################################################################################
-###                        ACL 2021 - *Title Redacted until end of anonymity Period*                                 ##
+##    ACL 2021 - Mind Your Outliers! Investigating the Negative Impact of Outliers on Active Learning for VQA       ##
 #######################################################################################################################
 
 entry!('lewis1994heterogeneous',
@@ -662,7 +662,7 @@ entry!('hoi2006batch',
 
 entry!('schein2007active',
   machineLearning(2007, 68),
-  title('Active learning for logistic regression: an evaluation'),
+  title('Active learning for logistic regression: An evaluation'),
   author('A. Schein and Lyle H. Ungar'),
   pages(235, 265)
 )
@@ -692,7 +692,7 @@ entry!('settles2009active',
 
 entry!('bigham2010vizwiz',
   uist(2010),
-  title('Vizwiz: nearly real-time answers to visual questions'),
+  title('{VizWiz}: nearly real-time answers to visual questions'),
   author('Jeffrey P Bigham and Chandrika Jayant and Hanjie Ji and Greg Little and Andrew Miller and Robert C Miller and Robin Miller and Aubrey Tatarowicz and Brandyn White and Samual White and Tom Yeh'),
   pages(333, 342)
 )
@@ -700,7 +700,7 @@ entry!('bigham2010vizwiz',
 entry!('houlsby2011bayesian',
   arxiv(2011, '1112.5745'),
   title('{B}ayesian active learning for classification and preference learning'),
-  author('Neil Houlsby and Ferenc Husz{\'a}r and Zoubin Ghahramani and M{\'a}t{\'e} Lengyel')
+  author('Neil Houlsby and Ferenc Husz{\\\'a}r and Zoubin Ghahramani and M{\\\'a}t{\\\'e} Lengyel')
 )
 
 entry!('khosla2012undoing',
@@ -779,9 +779,9 @@ entry!('lin2017active',
 )
 
 entry!('shen2017deep',
-  arxiv(2017, '1707.05928'),
   title('Deep active learning for named entity recognition'),
-  author('Yanyao Shen and Hyokun Yun and Zachary C Lipton and Yakov Kronrod and Animashree Anandkumar')
+  author('Yanyao Shen and Hyokun Yun and Zachary C Lipton and Yakov Kronrod and Animashree Anandkumar'),
+  inproceedings('Proceedings of the Second Workshop on Representation Learning for NLP (Repl4NLP)', 2017)
 )
 
 entry!('kendall2017uncertainties',
@@ -873,7 +873,7 @@ entry!('suhr2019nlvr2',
 
 entry!('tan2019lxmert',
   emnlp(2019),
-  title('LXMERT: Learning Cross-Modality Encoder Representations from Transformers'),
+  title('{LXMERT}: Learning Cross-Modality Encoder Representations from Transformers'),
   author('Hao Hao Tan and Mohit Bansal')
 )
 


### PR DESCRIPTION
Add ACL 2021 Final Camera-Ready Cites, fix punctuation, names, & capitalization of prior cites.